### PR TITLE
Fixed issues with catch incorrectly reading from map

### DIFF
--- a/internal/repl/helpers.go
+++ b/internal/repl/helpers.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"math/rand"
 	"strings"
-
-	"github.com/joshhartwig/pokedex/pkg/models"
 )
 
 // cleanInput takes a string and returns a slice of strings
@@ -25,7 +23,7 @@ func randomChance(percentage float64) bool {
 	return random <= ((percentage * 100) / 100)
 }
 
-func checkArgs(c *models.Config, args []string) error {
+func checkArgs(args []string) error {
 	if len(args) < 2 {
 		return errors.New("this command requires two arguments")
 	}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -37,7 +37,7 @@ func Repl(c *models.Config) {
 
 			err := cmd.Callback(cleanedInput...)
 			if err != nil {
-				fmt.Println("The command you just ran requires additional requirements")
+				fmt.Println("The command you just ran requires additional requirements", err)
 			}
 		}
 	}

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -31,3 +31,7 @@ func TestCleanInput(t *testing.T) {
 		}
 	}
 }
+
+func TestCatch(t *testing.T) {
+
+}


### PR DESCRIPTION
Fixed the issue when checking if the character exists in the models.Pokedex map, the logic was incorrect. We want to continue if we did not find the entry in the map. Previously we were incorrectly returning early if the character was not in the map, but this is desired behavior of catch. We would not be catching if the character was not in the map.